### PR TITLE
Azure Trace Exporter to Azure Monitor Layout

### DIFF
--- a/exporter/azure_monitor/README.md
+++ b/exporter/azure_monitor/README.md
@@ -1,0 +1,6 @@
+Azure Monitor helps developers and customers to monitor their application.
+As part of the whole story, we want to collect monitoring / instrumentation data from popular open source technologies.
+This project aims to support all OpenCensus SDKs piping data to Azure Monitor through the OneAgent.
+
+Project is still in very early development.
+

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -1,4 +1,6 @@
 package azure_monitor
+// Package: extension for exporters to Azure Monitor.
+// This includes examples on how to create azure exporters to send spans.
 
 import (
 	"fmt"
@@ -13,33 +15,38 @@ type AzureTraceExporter struct {
 	options            common.Options
 }
 
-func NewAzureTraceExporter(o common.Options) (*AzureTraceExporter, error) {
-	if o.InstrumentationKey == "" {
+/*	Creates an Azure Trace Exporter.
+	@param options holds specific attributes for the new exporter
+	@return The exporter created and error if there is any
+*/
+func NewAzureTraceExporter(options common.Options) (*AzureTraceExporter, error) {
+	if options.InstrumentationKey == "" {
 		return nil, errors.New("missing Instrumentation Key for Azure Exporter")
 	}
-	e := &AzureTraceExporter {
+	exporter := &AzureTraceExporter {
 		projectID:          "abcdefghijk",
-		InstrumentationKey: o.InstrumentationKey,
-		options:            o,
+		InstrumentationKey: options.InstrumentationKey,
+		options:            options,
 	}
-	return e, nil
+	return exporter, nil
 }
 
 var _ trace.Exporter = (*AzureTraceExporter)(nil)
 
-// Export SpanData to Azure Monitor
-// The () before the function name means it is a function of AzureTraceExporter
-func (e *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
-	baseObj := common.BaseObject {IKey : e.options.InstrumentationKey}
+/*	Opencensus trace function required by interface. Called for every span/trace call.
+	@param sd Span data retrieved by opencensus
+*/
+func (exporter *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
+	baseObj := common.BaseObject {IKey : exporter.options.InstrumentationKey}
 	envelope := common.Envelope {
 		BaseObject: baseObj,
 	}
 	envelope.Name = "Microsoft.ApplicationInsights.RemoteDependency"
 
 	transporter := common.Transporter{ 
-		Envel: envelope,
+		EnvelopeData: envelope,
 	}
-	transporter.Transmit(&e.options, &envelope)
+	transporter.Transmit(&exporter.options, &envelope)
 
 	fmt.Printf("Name: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\nStartTime: %s\nEndTime: %s\nAnnotations: %+v\n\n",
 		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID, sd.StartTime, sd.EndTime, sd.Annotations)

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -2,9 +2,47 @@ package azure_monitor
 
 import (
 	"fmt"
+	"errors"
+	"go.opencensus.io/exporter/azure_monitor/common"
+	"go.opencensus.io/trace"
 )
 
-func NewExporter() (int) {
-	fmt.Printf("hi man")
-	return 1
+
+type AzureTraceExporter struct {
+	projectID          string
+	InstrumentationKey string
+	options            common.Options
+}
+
+func NewAzureTraceExporter(o common.Options) (*AzureTraceExporter, error) {
+	if o.InstrumentationKey == "" {
+		return nil, errors.New("missing Instrumentation Key for Azure Exporter")
+	}
+	e := &AzureTraceExporter {
+		projectID:          "abcdefghijk",
+		InstrumentationKey: o.InstrumentationKey,
+		options:            o,
+	}
+	return e, nil
+}
+
+var _ trace.Exporter = (*AzureTraceExporter)(nil)
+
+//Export SpanData to Azure Monitor
+// The () before the function name means it is a function of AzureTraceExporter
+func (e *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
+	baseObj := common.BaseObject {IKey : e.options.InstrumentationKey}
+	envelope := common.Envelope {
+		BaseObject: baseObj,
+		//StartTime:  		sd.StartTime,
+	}
+	envelope.Name = "Microsoft.ApplicationInsights.RemoteDependency"
+
+	transporter := common.Transporter{ 
+		Envel: envelope,
+	}
+	transporter.Transmit(&e.options, &envelope)
+
+	fmt.Printf("Name: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\nStartTime: %s\nEndTime: %s\nAnnotations: %+v\n\n",
+		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID, sd.StartTime, sd.EndTime, sd.Annotations)
 }

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -1,0 +1,48 @@
+package azure_monitor
+
+import (
+	"fmt"
+	"errors"
+	"go.opencensus.io/exporter/azure_monitor/common"
+	"go.opencensus.io/trace"
+)
+
+
+type AzureTraceExporter struct {
+	projectID          string
+	InstrumentationKey string
+	options            common.Options
+}
+
+func NewAzureTraceExporter(o common.Options) (*AzureTraceExporter, error) {
+	if o.InstrumentationKey == "" {
+		return nil, errors.New("missing Instrumentation Key for Azure Exporter")
+	}
+	e := &AzureTraceExporter {
+		projectID:          "abcdefghijk",
+		InstrumentationKey: o.InstrumentationKey,
+		options:            o,
+	}
+	return e, nil
+}
+
+var _ trace.Exporter = (*AzureTraceExporter)(nil)
+
+//Export SpanData to Azure Monitor
+// The () before the function name means it is a function of AzureTraceExporter
+func (e *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
+	baseObj := common.BaseObject {IKey : e.options.InstrumentationKey}
+	envelope := common.Envelope {
+		BaseObject: baseObj,
+		//StartTime:  		sd.StartTime,
+	}
+	envelope.Name = "Microsoft.ApplicationInsights.RemoteDependency"
+
+	transporter := common.Transporter{ 
+		Envel: envelope,
+	}
+	transporter.Transmit(&e.options, &envelope)
+
+	fmt.Printf("Name: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\nStartTime: %s\nEndTime: %s\nAnnotations: %+v\n\n",
+		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID, sd.StartTime, sd.EndTime, sd.Annotations)
+}

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -1,0 +1,10 @@
+package azure_monitor
+
+import (
+	"fmt"
+)
+
+func NewExporter() (int) {
+	fmt.Printf("hi man")
+	return 1
+}

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -7,7 +7,6 @@ import (
 	"go.opencensus.io/trace"
 )
 
-
 type AzureTraceExporter struct {
 	projectID          string
 	InstrumentationKey string
@@ -28,13 +27,12 @@ func NewAzureTraceExporter(o common.Options) (*AzureTraceExporter, error) {
 
 var _ trace.Exporter = (*AzureTraceExporter)(nil)
 
-//Export SpanData to Azure Monitor
+// Export SpanData to Azure Monitor
 // The () before the function name means it is a function of AzureTraceExporter
 func (e *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
 	baseObj := common.BaseObject {IKey : e.options.InstrumentationKey}
 	envelope := common.Envelope {
 		BaseObject: baseObj,
-		//StartTime:  		sd.StartTime,
 	}
 	envelope.Name = "Microsoft.ApplicationInsights.RemoteDependency"
 

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"context" 
+)
+
+
+type AzureMonitorContext struct {
+    sdkVersion ai_internal_sdkVersion
+}
+
+type ai_internal_sdkVersion struct {
+    goPlatform_version string
+    opencensus_version string
+    ext_version string
+}
+
+type BaseObject struct {
+	ver int
+	Name string
+	time string
+	sampleRate int
+	success bool
+	IKey string
+	tags string
+	data string
+}
+
+type Options struct {
+	ServiceName        	string
+	InstrumentationKey 	string
+	Context            	context.Context
+	EndPoint			string
+	TimeOut				int
+}
+
+type Data struct {
+	baseDate string
+	baseType string
+}
+
+type Envelope struct {
+	BaseObject
+}
+
+type RemoteDependency struct {
+	BaseObject
+	id string
+	duration string
+	responseCode string
+	url string
+	properties string
+	measurements string
+}
+
+type Request struct {
+	BaseObject
+	id string
+	duration string
+	responseCode string
+	url string
+	properties string
+	measurements string
+}

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -1,30 +1,29 @@
 package common
+// Package: Structs commonly used for both trace and log exporters
 
 import (
 	"context" 
 )
 
-// Some of these structs will be used in future PRs
-
 type AzureMonitorContext struct {
-    sdkVersion ai_internal_sdkVersion
+    SdkVersion ai_internal_sdkVersion
 }
 
 type ai_internal_sdkVersion struct {
-    goPlatform_version string
-    opencensus_version string
-    ext_version string
+    GoPlatform_version string
+    Opencensus_version string
+    Ext_version string
 }
 
 type BaseObject struct { // Used to avoid repeat attributes
-	ver int
+	Version int
 	Name string
-	time string
-	sampleRate int
-	success bool
+	Time string
+	SampleRate int
+	Success bool
 	IKey string
-	tags string
-	data string
+	Tags string
+	Data string
 }
 
 type Options struct {
@@ -36,30 +35,30 @@ type Options struct {
 }
 
 type Data struct {
-	baseDate string
-	baseType string
+	BaseDate string
+	BaseType string
 }
 
-type Envelope struct { // Will add more for next PR
+type Envelope struct { //TODO: Add more attributes
 	BaseObject
 }
 
 type RemoteDependency struct {
 	BaseObject
-	id string
-	duration string
-	responseCode string
-	url string
-	properties string
-	measurements string
+	Id string
+	Duration string
+	ResponseCode string
+	Url string
+	Properties string
+	Measurements string
 }
 
 type Request struct {
 	BaseObject
-	id string
-	duration string
-	responseCode string
-	url string
-	properties string
-	measurements string
+	Id string
+	Duration string
+	ResponseCode string
+	Url string
+	Properties string
+	Measurements string
 }

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -4,6 +4,7 @@ import (
 	"context" 
 )
 
+// Some of these structs will be used in future PRs
 
 type AzureMonitorContext struct {
     sdkVersion ai_internal_sdkVersion
@@ -15,7 +16,7 @@ type ai_internal_sdkVersion struct {
     ext_version string
 }
 
-type BaseObject struct {
+type BaseObject struct { // Used to avoid repeat attributes
 	ver int
 	Name string
 	time string
@@ -39,7 +40,7 @@ type Data struct {
 	baseType string
 }
 
-type Envelope struct {
+type Envelope struct { // Will add more for next PR
 	BaseObject
 }
 

--- a/exporter/azure_monitor/common/transport.go
+++ b/exporter/azure_monitor/common/transport.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"encoding/json"
+	"fmt"
+)
+
+
+
+//We can then use this for logs and trace exporter.
+type Transporter struct {
+	Envel Envelope
+	
+}
+
+func (e *Transporter) Transmit(o *Options, env *Envelope) {
+	fmt.Println("Begin Transmission")
+	bytesRepresentation, err := json.Marshal(env)
+	if err != nil {
+		fmt.Println("Error: json conversion for envelope\n")
+	}
+	fmt.Println(env.BaseObject.IKey)
+	reponse, err := http.Post(
+		o.EndPoint, 							//url
+		"application/json",		 				//header
+		bytes.NewBuffer(bytesRepresentation),	//data
+	)
+	if err != nil {
+		fmt.Println("Error: post error %d\n", err)
+	}
+
+	defer reponse.Body.Close() // prevent possible resource leak
+
+	var result map[string]interface{}
+	
+	err = json.NewDecoder(reponse.Body).Decode(&result)
+	if err != nil {
+		fmt.Println("Error: check decoder\n")
+	}
+	log.Println(result)
+	log.Println(result["data"])
+	fmt.Println("End Transmission")
+}

--- a/exporter/azure_monitor/common/transport.go
+++ b/exporter/azure_monitor/common/transport.go
@@ -8,21 +8,19 @@ import (
 	"fmt"
 )
 
-
-
-//We can then use this for logs and trace exporter.
+// We can then use this for logs and trace exporter.
 type Transporter struct {
 	Envel Envelope
 	
 }
 
 func (e *Transporter) Transmit(o *Options, env *Envelope) {
-	fmt.Println("Begin Transmission")
+	fmt.Println("Begin Transmission") // For debugging
 	bytesRepresentation, err := json.Marshal(env)
 	if err != nil {
 		fmt.Println("Error: json conversion for envelope\n")
 	}
-	fmt.Println(env.BaseObject.IKey)
+	
 	reponse, err := http.Post(
 		o.EndPoint, 							//url
 		"application/json",		 				//header
@@ -35,12 +33,12 @@ func (e *Transporter) Transmit(o *Options, env *Envelope) {
 	defer reponse.Body.Close() // prevent possible resource leak
 
 	var result map[string]interface{}
-	
 	err = json.NewDecoder(reponse.Body).Decode(&result)
 	if err != nil {
 		fmt.Println("Error: check decoder\n")
 	}
+
 	log.Println(result)
 	log.Println(result["data"])
-	fmt.Println("End Transmission")
+	fmt.Println("End Transmission") // For debugging
 }

--- a/exporter/azure_monitor/common/transport.go
+++ b/exporter/azure_monitor/common/transport.go
@@ -1,4 +1,5 @@
 package common
+// Package: Structs commonly used for both trace and log exporters
 
 import (
 	"bytes"
@@ -10,19 +11,24 @@ import (
 
 // We can then use this for logs and trace exporter.
 type Transporter struct {
-	Envel Envelope
+	EnvelopeData Envelope
 	
 }
 
-func (e *Transporter) Transmit(o *Options, env *Envelope) {
+/*	Transmits envelope data to Azure Monitor.
+	@param options holds specific attributes for exporter
+	@param envelope Contains the data package to be transmitted
+	@return The exporter created, and error if there is any
+*/
+func (e *Transporter) Transmit(options *Options, envelope *Envelope) {
 	fmt.Println("Begin Transmission") // For debugging
-	bytesRepresentation, err := json.Marshal(env)
+	bytesRepresentation, err := json.Marshal(envelope)
 	if err != nil {
 		fmt.Println("Error: json conversion for envelope\n")
 	}
 	
 	reponse, err := http.Post(
-		o.EndPoint, 							//url
+		options.EndPoint, 						//url
 		"application/json",		 				//header
 		bytes.NewBuffer(bytesRepresentation),	//data
 	)

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -1,10 +1,34 @@
 package main
 
 import (
+	"context" // similar to log
+	"log"
 	"go.opencensus.io/exporter/azure_monitor"
+	"go.opencensus.io/exporter/azure_monitor/common"
+	"go.opencensus.io/trace"
 )
 
+
 func main() {
-	exporter := azure_monitor.NewExporter()
-	exporter = exporter
+
+	ctx := context.Background()
+
+	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
+		InstrumentationKey: "111111111111111111", // add your InstrumentationKey
+		EndPoint: 			"https://dc.services.visualstudio.com/v2/track",
+		TimeOut: 			10.0,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(exporter)
+
+	ctx, span := trace.StartSpan(ctx, "/foo") // This calls the function ExportSpan written in azure_monitor.go 
+	span.End()
+
 }
+
+
+

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"go.opencensus.io/exporter/azure_monitor"
+)
+
+func main() {
+	exporter := azure_monitor.NewExporter()
+	exporter = exporter
+}

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -1,20 +1,19 @@
 package main
 
 import (
-	"context" // similar to log
+	"context"
 	"log"
 	"go.opencensus.io/exporter/azure_monitor"
 	"go.opencensus.io/exporter/azure_monitor/common"
 	"go.opencensus.io/trace"
 )
 
-
 func main() {
 
 	ctx := context.Background()
 
 	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
-		InstrumentationKey: "d07ba4f7-7546-47b4-b3e0-7fa203f17f6a", //  "111111111111111111", // add your InstrumentationKey
+		InstrumentationKey: "111111111111111111", // add your InstrumentationKey
 		EndPoint: 			"https://dc.services.visualstudio.com/v2/track",
 		TimeOut: 			10.0,
 	})
@@ -25,10 +24,6 @@ func main() {
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)
 
-	ctx, span := trace.StartSpan(ctx, "/foo") // This calls the function ExportSpan written in azure_monitor.go 
+	_, span := trace.StartSpan(ctx, "/foo") // This calls the function ExportSpan written in azure_monitor.go 
 	span.End()
-
 }
-
-
-

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -1,4 +1,5 @@
 package main
+// Package: Runs code for using Azure exporter
 
 import (
 	"context"

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context" // similar to log
+	"log"
+	"go.opencensus.io/exporter/azure_monitor"
+	"go.opencensus.io/exporter/azure_monitor/common"
+	"go.opencensus.io/trace"
+)
+
+
+func main() {
+
+	ctx := context.Background()
+
+	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
+		InstrumentationKey: "d07ba4f7-7546-47b4-b3e0-7fa203f17f6a", //  "111111111111111111", // add your InstrumentationKey
+		EndPoint: 			"https://dc.services.visualstudio.com/v2/track",
+		TimeOut: 			10.0,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(exporter)
+
+	ctx, span := trace.StartSpan(ctx, "/foo") // This calls the function ExportSpan written in azure_monitor.go 
+	span.End()
+
+}
+
+
+


### PR DESCRIPTION
-AzureTraceExporter struct created
-Opencensus Trace called
-Common structs for both Trace and Log exporter
-Transport struct to send to end point but IKey is invalid

@lzchen @reyang 