### PR TITLE
Use standard opencensus example

### DIFF
--- a/exporter/azure_monitor/example/server.go
+++ b/exporter/azure_monitor/example/server.go
@@ -1,4 +1,5 @@
 package main
+// Package: Runs code for using Azure exporter
 
 import (
 	"context"
@@ -30,7 +31,7 @@ func main() {
 		trace.RegisterExporter(exporter)
 	
 		_, span := trace.StartSpan(ctx, "/serverSide") // This calls the function ExportSpan written in azure_monitor.go 
-		span.End() //TODO: Investigate why this span is not considered trace.SpanKindServer
+		span.End()
 	})
 
 	och := &ochttp.Handler{


### PR DESCRIPTION
I am using the opencensus client example (https://opencensus.io/guides/http/go/net_http/client/) so I properly generate client spans. I thought the problem was because of my code, but it was because of the incomplete example I had before. 

@reyang @lzchen 