### PR TITLE
Register Azure Monitor trace exporter

### DIFF
--- a/exporter/azure_monitor/example/ocClient.go
+++ b/exporter/azure_monitor/example/ocClient.go
@@ -7,11 +7,24 @@ import (
 	"log"
 	"net/http"
 
+	"go.opencensus.io/exporter/azure_monitor"
+	"go.opencensus.io/exporter/azure_monitor/common"
 	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/trace"
 )
 
 func main() {
 	ctx := context.Background() // In other usages, the context would have been passed down after starting some traces.
+	
+	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
+		InstrumentationKey: "11111111-1111-1111-1111-111111111111", // add your InstrumentationKey
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(exporter)
+
 	req, _ := http.NewRequest("GET", "https://opencensus.io/", nil)
 
 	// It is imperative that req.WithContext is used to

--- a/exporter/azure_monitor/example/ocServer.go
+++ b/exporter/azure_monitor/example/ocServer.go
@@ -4,18 +4,29 @@ import (
 	"log"
 	"net/http"
 
+	"go.opencensus.io/exporter/azure_monitor"
+	"go.opencensus.io/exporter/azure_monitor/common"
 	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/trace"
 )
 
 func main() {
 	originalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, World!"))
+		exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
+			InstrumentationKey: "11111111-1111-1111-1111-111111111111", // add your InstrumentationKey
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+		trace.RegisterExporter(exporter)
 	})
 	och := &ochttp.Handler{
 		Handler: originalHandler, // The handler you'd have used originally
 	}
 
-	// Now use the instrumnted handler
+	// Now use the instrumented handler
 	if err := http.ListenAndServe(":8080", och); err != nil {
 		log.Fatalf("Failed to run the server: %v", err)
 	}

--- a/exporter/azure_monitor/example/ocServer.go
+++ b/exporter/azure_monitor/example/ocServer.go
@@ -11,16 +11,17 @@ import (
 )
 
 func main() {
+	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
+		InstrumentationKey: "11111111-1111-1111-1111-111111111111", // add your InstrumentationKey
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(exporter)
+	
 	originalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, World!"))
-		exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
-			InstrumentationKey: "11111111-1111-1111-1111-111111111111", // add your InstrumentationKey
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
-		trace.RegisterExporter(exporter)
 	})
 	och := &ochttp.Handler{
 		Handler: originalHandler, // The handler you'd have used originally


### PR DESCRIPTION
In order for this example to send traces to azure monitor, the trace exporter needs to be registered. I also fixed a typo.

@lzchen @reyang