### PR TITLE
Add default settings for exporter in constructor

### DIFF
--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -57,14 +57,14 @@ func (exporter *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
 			Success : true,
 		}
 		if _, isIncluded := sd.Attributes["http.method"]; isIncluded {
-			currentData.Name = sd.Attributes["http.method"].(string)
+			currentData.Name = fmt.Sprintf("%s", sd.Attributes["http.method"])
 		}
 		if _, isIncluded := sd.Attributes["http.url"]; isIncluded {
-			currentData.Name = currentData.Name + " " + sd.Attributes["http.url"].(string)
-			currentData.Url = sd.Attributes["'http.url"].(string)
+			currentData.Name = fmt.Sprintf("%s %s", currentData.Name, sd.Attributes["http.url"])
+			currentData.Url = fmt.Sprintf("%s", sd.Attributes["http.url"])
 		}
 		if _, isIncluded := sd.Attributes["http.status_code"]; isIncluded {
-			currentData.ResponseCode = sd.Attributes["http.status_code"].(string)
+			currentData.ResponseCode = fmt.Sprintf("%d", sd.Attributes["http.status_code"])
 		}
 		envelope.DataToSend = common.Data {
 			BaseData : currentData,
@@ -84,11 +84,11 @@ func (exporter *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
 		if sd.SpanKind == trace.SpanKindClient {
 			currentData.Type = "HTTP"
 			if _, isIncluded := sd.Attributes["http.url"]; isIncluded {
-				Url := sd.Attributes["http.method"].(string)
+				Url := fmt.Sprintf("%s", sd.Attributes["http.url"])
 				currentData.Name = Url // TODO: parse URL before assignment
 			}
 			if _, isIncluded := sd.Attributes["http.status_code"]; isIncluded {
-				currentData.ResultCode = sd.Attributes["http.status_code"].(string)
+				currentData.ResultCode = fmt.Sprintf("%d", sd.Attributes["http.status_code"])
 			}
 		} else {
 			currentData.Type = "INPROC" 

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -14,17 +14,17 @@ import (
 )
 
 type AzureTraceExporter struct {
-	InstrumentationKey 	string
+	InstrumentationKey string
 	Options            common.Options
 }
 
 /*	Azure Trace Exporter constructor with default settings. The instrumentation key
-	can be set with an environmental variable, or it could be set later.
+	needs to be set after calling this function. TODO: Add ability to get ikey from 
+	environment variable.
 	@return The exporter created with the instrumentation key if already set.
 */
 func NewAzureTraceExporter() (*AzureTraceExporter) {
 	exporter := new(AzureTraceExporter)
-	exporter.InstrumentationKey = os.Getenv("APPINSIGHTS_INSTRUMENTATIONKEY")
 	exporter.Options.EndPoint = "https://dc.services.visualstudio.com/v2/track"
 	exporter.Options.TimeOut = 10.0
 	return exporter

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -20,20 +20,20 @@ type AzureTraceExporter struct {
 	@param options holds specific attributes for the new exporter
 	@return The exporter created and error if there is any
 */
-func NewAzureTraceExporter(IKey string) (*AzureTraceExporter, error) {
-	if IKey == "" {
+func NewAzureTraceExporter(Options common.Options) (*AzureTraceExporter, error) {
+	if Options.InstrumentationKey == "" {
 		return nil, errors.New("missing Instrumentation Key for Azure Exporter")
 	}
-	currentOptions := common.Options {
-		InstrumentationKey: IKey,
-		EndPoint:           "https://dc.services.visualstudio.com/v2/track",
-		TimeOut: 			10.0,
+	if Options.EndPoint == "" {
+		Options.EndPoint = "https://dc.services.visualstudio.com/v2/track"
+	}
+	if Options.TimeOut == 0 {
+		Options.TimeOut = 10.0
 	}
 	exporter := &AzureTraceExporter {
-		InstrumentationKey: currentOptions.InstrumentationKey,
-		Options:            currentOptions,
+		Options:            Options,
 	}
-	
+
 	return exporter, nil
 }
 

--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -17,7 +17,6 @@ import (
 type Exporter struct {
 	ServiceName         string
 	InstrumentationKey  string
-	Context             context.Context
 	EndPoint            string
 	TimeOut             int
 }
@@ -26,7 +25,6 @@ type Exporter struct {
 type Options struct {
 	ServiceName         string
 	InstrumentationKey  string	// required by user
-	Context             context.Context
 	EndPoint            string
 	TimeOut             int
 }

--- a/exporter/azure_monitor/common.go
+++ b/exporter/azure_monitor/common.go
@@ -1,8 +1,7 @@
-package common
+package azure_monitor
 // Package: Structs commonly used for both trace and log exporters
 
 import (
-	"context" 
 	"fmt"
 	"os"
 )
@@ -21,14 +20,6 @@ func getHostName() (string) {
 		fmt.Println("Problem with getting host name")
 	}
 	return hostName
-}
-
-type Options struct {
-	ServiceName         string
-	InstrumentationKey  string
-	Context             context.Context
-	EndPoint            string
-	TimeOut             int
 }
 
 type Data struct {

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -24,6 +24,7 @@ func getHostName() (string) {
 }
 
 type Options struct {
+	InstrumentationKey  string
 	ServiceName        	string
 	Context            	context.Context
 	EndPoint			string

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -2,6 +2,7 @@ package common
 // Package: Structs commonly used for both trace and log exporters
 
 import (
+	"context" 
 	"fmt"
 	"os"
 )
@@ -23,6 +24,8 @@ func getHostName() (string) {
 }
 
 type Options struct {
+	ServiceName        	string
+	Context            	context.Context
 	EndPoint			string
 	TimeOut				int
 }

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -24,11 +24,11 @@ func getHostName() (string) {
 }
 
 type Options struct {
+	ServiceName         string
 	InstrumentationKey  string
-	ServiceName        	string
-	Context            	context.Context
-	EndPoint			string
-	TimeOut				int
+	Context             context.Context
+	EndPoint            string
+	TimeOut             int
 }
 
 type Data struct {

--- a/exporter/azure_monitor/common/common.go
+++ b/exporter/azure_monitor/common/common.go
@@ -2,7 +2,6 @@ package common
 // Package: Structs commonly used for both trace and log exporters
 
 import (
-	"context" 
 	"fmt"
 	"os"
 )
@@ -24,9 +23,6 @@ func getHostName() (string) {
 }
 
 type Options struct {
-	ServiceName        	string
-	InstrumentationKey 	string
-	Context            	context.Context
 	EndPoint			string
 	TimeOut				int
 }

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"log"
 	
 	"go.opencensus.io/exporter/azure_monitor"
 	"go.opencensus.io/trace"
@@ -11,8 +12,12 @@ import (
 func main() {
 	ctx := context.Background()
 
-	exporter := azure_monitor.NewAzureTraceExporter()
-	exporter.Options.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
+	exporter, err := azure_monitor.NewExporter(azure_monitor.Options{
+        InstrumentationKey: "111a0d2f-ab53-4b62-a54f-4722f09fd136", // "11111111-1111-1111-1111-111111111111"
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -12,7 +12,7 @@ func main() {
 	ctx := context.Background()
 
 	exporter := azure_monitor.NewAzureTraceExporter()
-	exporter.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
+	exporter.Options.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
 
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -12,8 +12,7 @@ func main() {
 	ctx := context.Background()
 
 	exporter := azure_monitor.NewAzureTraceExporter()
-	// Line below only required if APPINSIGHTS_INSTRUMENTATIONKEY is not set
-	//exporter.InstrumentationKey = "111a0d2f-ab53-4b62-a54f-4722f09fd136" 
+	exporter.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
 
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)

--- a/exporter/azure_monitor/example/main.go
+++ b/exporter/azure_monitor/example/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"log"
 	
 	"go.opencensus.io/exporter/azure_monitor"
 	"go.opencensus.io/trace"
@@ -12,10 +11,9 @@ import (
 func main() {
 	ctx := context.Background()
 
-	exporter, err := azure_monitor.NewAzureTraceExporter("111a0d2f-ab53-4b62-a54f-4722f09fd136")
-	if err != nil {
-		log.Fatal(err)
-	}
+	exporter := azure_monitor.NewAzureTraceExporter()
+	// Line below only required if APPINSIGHTS_INSTRUMENTATIONKEY is not set
+	//exporter.InstrumentationKey = "111a0d2f-ab53-4b62-a54f-4722f09fd136" 
 
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)

--- a/exporter/azure_monitor/example/ocClient.go
+++ b/exporter/azure_monitor/example/ocClient.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"go.opencensus.io/exporter/azure_monitor"
-	"go.opencensus.io/exporter/azure_monitor/common"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/trace"
 )
@@ -16,8 +15,12 @@ import (
 func main() {
 	ctx := context.Background() // In other usages, the context would have been passed down after starting some traces.
 	
-	exporter := azure_monitor.NewAzureTraceExporter()
-	exporter.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
+	exporter, err := azure_monitor.NewExporter(azure_monitor.Options{
+        InstrumentationKey: "11111111-1111-1111-1111-111111111111", // "11111111-1111-1111-1111-111111111111"
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 	
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)

--- a/exporter/azure_monitor/example/ocClient.go
+++ b/exporter/azure_monitor/example/ocClient.go
@@ -16,12 +16,9 @@ import (
 func main() {
 	ctx := context.Background() // In other usages, the context would have been passed down after starting some traces.
 	
-	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
-		InstrumentationKey: "11111111-1111-1111-1111-111111111111", // add your InstrumentationKey
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
+	exporter := azure_monitor.NewAzureTraceExporter()
+	exporter.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
+	
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)
 

--- a/exporter/azure_monitor/example/ocServer.go
+++ b/exporter/azure_monitor/example/ocServer.go
@@ -5,14 +5,17 @@ import (
 	"net/http"
 
 	"go.opencensus.io/exporter/azure_monitor"
-	"go.opencensus.io/exporter/azure_monitor/common"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/trace"
 )
 
 func main() {
-	exporter := azure_monitor.NewAzureTraceExporter()
-	exporter.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
+	exporter, err := azure_monitor.NewExporter(azure_monitor.Options{
+        InstrumentationKey: "11111111-1111-1111-1111-111111111111", // "11111111-1111-1111-1111-111111111111"
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 	
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)

--- a/exporter/azure_monitor/example/ocServer.go
+++ b/exporter/azure_monitor/example/ocServer.go
@@ -11,12 +11,9 @@ import (
 )
 
 func main() {
-	exporter, err := azure_monitor.NewAzureTraceExporter(common.Options{
-		InstrumentationKey: "11111111-1111-1111-1111-111111111111", // add your InstrumentationKey
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
+	exporter := azure_monitor.NewAzureTraceExporter()
+	exporter.InstrumentationKey = "11111111-1111-1111-1111-111111111111"
+	
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(exporter)
 	

--- a/exporter/azure_monitor/transport.go
+++ b/exporter/azure_monitor/transport.go
@@ -1,4 +1,4 @@
-package common
+package azure_monitor
 // Package: Structs commonly used for both trace and log exporters
 
 import (
@@ -18,13 +18,13 @@ type Transporter struct {
 	@param envelope Contains the data package to be transmitted
 	@return The exporter created, and error if there is any
 */
-func (e *Transporter) Transmit(options *Options, envelope *Envelope) {
+func (e *Transporter) Transmit(exporter *Exporter, envelope *Envelope) {
 	bytesRepresentation, err := json.Marshal(envelope)
 	if err != nil {
 		fmt.Println(err)
 	}
 	response, err := http.Post(
-		options.EndPoint, 						//url
+		exporter.EndPoint, 						//url
 		"application/json",		 				//header
 		bytes.NewBuffer(bytesRepresentation),	//data
 	)


### PR DESCRIPTION
All settings for the exporter can be edited and found under exporter.Options and there are default settings for end point and time out. I removed the input for `NewAzureTraceExporter` so that the go constructor is cleaner. User now has to edit iKey after constructing the exporter.

@lzchen @reyang