### PR TITLE
Fix parent id format so parent/child spans link in Azure Monitor

### DIFF
--- a/exporter/azure_monitor/azure_monitor.go
+++ b/exporter/azure_monitor/azure_monitor.go
@@ -51,8 +51,7 @@ func (exporter *AzureTraceExporter) ExportSpan(sd *trace.SpanData) {
 
 	envelope.Tags["ai.operation.id"] = sd.SpanContext.TraceID.String()
 	if sd.ParentSpanID.String() != "0000000000000000" {
-		envelope.Tags["ai.operation.parentId"] = "|" + sd.SpanContext.TraceID.String() + 
-												 "." + sd.ParentSpanID.String()
+		envelope.Tags["ai.operation.parentId"] = "|" + sd.SpanContext.TraceID.String() + "." + sd.ParentSpanID.String() + "."
 	}
 	if sd.SpanKind == trace.SpanKindServer {
 		envelope.Name = "Microsoft.ApplicationInsights.Request"


### PR DESCRIPTION
I never pushed this fix from my local machine to this repo. I realized this mistake when I tried to reuse this code here (https://github.com/ChrisCoe/azure-linux-extensions/pull/5) 

This change should format child spans to be under parent spans in Azure Monitor.
@reyang @simathih @lzchen